### PR TITLE
Optional buttons for increasing and decreasing the volume

### DIFF
--- a/src/__tests__/index.ts
+++ b/src/__tests__/index.ts
@@ -230,7 +230,7 @@ describe("public interface", () => {
       })
 
       it("should register all services with the name provided in the config", () => {
-        services.forEach(service =>
+        services.forEach((service) =>
           expect(service.displayName).toStrictEqual(config.name)
         )
       })
@@ -271,7 +271,7 @@ describe("public interface", () => {
       })
 
       it("should register all services with the name provided in the config", () => {
-        services.forEach(service =>
+        services.forEach((service) =>
           expect(service.displayName).toStrictEqual(config.name)
         )
       })
@@ -312,7 +312,7 @@ describe("public interface", () => {
       })
 
       it("should register all services with the name provided in the config", () => {
-        services.forEach(service =>
+        services.forEach((service) =>
           expect(service.displayName).toStrictEqual(config.name)
         )
       })
@@ -365,7 +365,7 @@ describe("public interface", () => {
       })
 
       it("should register all services with the name provided in the config", () => {
-        services.forEach(service =>
+        services.forEach((service) =>
           expect(service.displayName).toStrictEqual(config.name)
         )
       })

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,13 +1,20 @@
 export interface Config {
   name: string
   services?: Service[]
+  initialVolume?: number
+  initiallyMuted?: boolean
   logarithmic?: boolean
+  delta?: number
+  delay?: number
+  cached?: boolean
 }
 
 export enum Service {
   Lightbulb = "lightbulb",
   Speaker = "speaker",
   Fan = "fan",
+  IncreaseVolumeButton = "increase",
+  DecreaseVolumeButton = "decrease",
 }
 
 export default Config

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,12 +41,12 @@ class ComputerSpeakers implements Accessory {
     this.log = log
     const name = config.name
     const services = config.services || [ConfigService.Lightbulb]
-    const initialVolume = config["initialVolume"] || null
-    const initiallyMuted = config["initiallyMuted"] || null
+    const initialVolume = config.initialVolume || null
+    const initiallyMuted = config.initiallyMuted || null
     const logarithmic = config.logarithmic || false
-    const delta = config["delta"] || undefined
-    const delay = config["delay"] || 200
-    this.cached = logarithmic && (config["cached"] || false)
+    const delta = config.delta || undefined
+    const delay = config.delay || 200
+    this.cached = logarithmic && (config.cached || false)
     this.currentVolume = 0
 
     if (services.indexOf(ConfigService.Speaker) > -1) {
@@ -147,7 +147,7 @@ class ComputerSpeakers implements Accessory {
 
     if (initialVolume != null) {
       log.debug("Setting initial volume")
-      this.setVolume(logarithmic, initialVolume, () => {})
+      this.setVolume(logarithmic, initialVolume, () => { /* do nothing */ })
     } else if (this.cached) {
       log.debug("Using cached volume without initial value and thus reading current system volume")
       loudness.getVolume().then((homekitVolume) => {
@@ -156,7 +156,7 @@ class ComputerSpeakers implements Accessory {
     }
     if (initiallyMuted != null) {
       log.debug("Setting initial mute status")
-      this.setMuted(initiallyMuted, () => {})
+      this.setMuted(initiallyMuted, () => { /* do nothing */ })
     }
 
     setTimeout(function() {
@@ -303,7 +303,7 @@ class ComputerSpeakers implements Accessory {
 
       this.getSystemVolume()
         .then((homekitVolume) => {
-          var volume = logarithmic
+          let volume = logarithmic
             ? Math.pow(10, homekitVolume / (100 / Math.log10(101))) - 1
             : homekitVolume
           this.log.debug(`Got current volume: ${homekitVolume}%`)
@@ -322,7 +322,7 @@ class ComputerSpeakers implements Accessory {
           volume = logarithmic
             ? Math.log10(1 + volume) * (100 / Math.log10(101))
             : volume
-          if (!this.cached && volume == homekitVolume) {
+          if (!this.cached && volume === homekitVolume) {
             if (volume < 100 && delta > 0) { volume++ }
             else if (volume > 0 && delta < 0) { volume-- }
           }


### PR DESCRIPTION
Hi Joseph

Would it please be possible that you merge this pull request?  I have added two stateless buttons that increase or decrease the volume.  The two buttons can then be used with a HomeKit remote, e.g., a Hue remote, for controlling the volume.  I have further adjusted the function that converts volume levels on a logarithmic scale and added caching for the float volume values such that volume can be controlled more smoothly (in particular with the two new buttons).

Thanks in advance,
Francesco

PS: I might be a good idea to publish the code with npm on a regular basis.  The available version is three years old, see https://www.npmjs.com/package/homebridge-pc-volume.