### PR TITLE
Only distribute `build` directory to NPM

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,13 +1,2 @@
-.github/
-.homebridge-debug/
-scripts/
-src/
-.codecov.yml
-.gitignore
-.huskyrc
-.lintstagedrc
-.npmignore
-.prettierrc
-jest.config.js
-tsconfig.json
-tslint.json
+*
+!build/*


### PR DESCRIPTION
Some other files, such as README and package.json will automatically be included